### PR TITLE
Enable support for Julia 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - osx
   - linux
 julia:
+  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
+julia 0.4
 DataStructures 0.5.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,12 @@
 # This file contains code that was formerly part of Julia. License is MIT: http://julialang.org/license
 
 using QuadGK
-using Base.Test
+if isdefined(Base.Test, Symbol("@testset"))
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 import QuadGK: quadgk, gauss, kronrod
 


### PR DESCRIPTION
Apparently there is at least one package that wants to depend on QuadGK.jl and still maintain support for 0.4, and since Julia-version-conditional package dependencies isn't a thing at the moment, this is easier and preferable to conditionally calling Pkg.add (which breaks tracking of what was installed because the user asked for it, vs as a dependency).