### PR TITLE
Override quadgk deprecation in Base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -3,6 +3,11 @@
 __precompile__()
 module QuadGK
 
+# see PRs #19741 and #22763
+if v"0.6.0-dev.1764" ≤ VERSION < v"0.7.0-DEV.986" && isdefined(Base, :quadgk)
+    import Base: quadgk
+end
+
 if !isdefined(Base, :QuadGK)
     export quadgk, gauss, kronrod
 end


### PR DESCRIPTION
Fixes #8, e.g. on julia 0.6:

```
julia-0.6> using QuadGK

julia-0.6> quadgk(sin, 0, 1)
(0.4596976941318603, 5.551115123125783e-17)
```

On julia 0.4 and 0.5, the same code will use the version from `Base`, unless calls to `quadgk` are qualified explicitly.

This should ensure a smooth transition.

I used [this commit](https://github.com/JuliaLang/julia/commit/dbbd7e510d54810071d81acfd849e657bbb36dbd) for computing the julia version.

This also adds julia 0.6 to the Travis tests.