### PR TITLE
Load LinearAlgebra standard library

### DIFF
--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -13,7 +13,7 @@ if !isdefined(Base, :QuadGK)
 end
 
 using Compat
-using DataStructures
+using DataStructures, Compat.LinearAlgebra
 import Base: isless, Order.Reverse, AnyDict
 
 # Adaptive Gauss-Kronrod quadrature routines (arbitrary precision),


### PR DESCRIPTION
Running tests shows another warning:

```
┌ Warning: `scale!(A::AbstractArray, b::Number)` is deprecated, use `mul1!(A, b)` instead.
│   caller = eigvec1(::Array{BigFloat,1}, ::BigFloat, ::Int64) at QuadGK.jl:322
└ @ QuadGK QuadGK.jl:322
```

but doesn't look like `Compat` supports `mul1!`.