### PR TITLE
Type stability

### DIFF
--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -47,11 +47,11 @@ const rulecache = AnyDict( (Float64,7) => # precomputed in 100-bit arith.
      4.1795918367346938775510204081658e-01]) )
 
 # integration segment (a,b), estimated integral I, and estimated error E
-struct Segment
-    a::Number
-    b::Number
-    I
-    E
+struct Segment{TB<:Number,TI,TE}
+    a::TB
+    b::TB
+    I::TI
+    E::TE
 end
 isless(i::Segment, j::Segment) = isless(i.E, j.E)
 

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -112,7 +112,7 @@ function do_quadgk_common(f, s::TS, n, ::Type{Tw}, abstol, reltol, maxevals, nrm
     key = rulekey(Tw,n)
     x,w,gw = haskey(rulecache, key) ? rulecache[key] :
        (rulecache[key] = kronrod(Tw, n))
-    segs = heapify([evalrule(f, s[i], s[i+1], x, w, gw, nrm) for i in 1:length(s)-1], order = Reverse)
+    segs = heapify([evalrule(f, s[i], s[i+1], x, w, gw, nrm) for i in 1:length(s)-1], Reverse)
     numevals = (2n+1) * length(segs)
     I = segs[1].I
     E = segs[1].E

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -112,7 +112,7 @@ function do_quadgk_common(f, s::TS, n, ::Type{Tw}, abstol, reltol, maxevals, nrm
     key = rulekey(Tw,n)
     x,w,gw = haskey(rulecache, key) ? rulecache[key] :
        (rulecache[key] = kronrod(Tw, n))
-    segs = sort([evalrule(f, s[i], s[i+1], x, w, gw, nrm) for i in 1:length(s)-1], order = Reverse)
+    segs = heapify([evalrule(f, s[i], s[i+1], x, w, gw, nrm) for i in 1:length(s)-1], order = Reverse)
     numevals = (2n+1) * length(segs)
     I = segs[1].I
     E = segs[1].E

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -112,7 +112,7 @@ function do_quadgk_common(f, s::TS, n, ::Type{Tw}, abstol, reltol, maxevals, nrm
     key = rulekey(Tw,n)
     x,w,gw = haskey(rulecache, key) ? rulecache[key] :
        (rulecache[key] = kronrod(Tw, n))
-    segs = heapify([evalrule(f, s[i], s[i+1], x, w, gw, nrm) for i in 1:length(s)-1], Reverse)
+    segs = heapify!([evalrule(f, s[i], s[i+1], x, w, gw, nrm) for i in 1:length(s)-1], Reverse)
     numevals = (2n+1) * length(segs)
     I = segs[1].I
     E = segs[1].E


### PR DESCRIPTION
A first step towards fixing https://github.com/JuliaMath/QuadGK.jl/issues/15 https://github.com/JuliaMath/QuadGK.jl/issues/19 https://github.com/JuliaMath/QuadGK.jl/issues/20

Still type unstable:
```julia
@code_warntype QuadGK.preprocess_real
```

```julia
@code_warntype QuadGK.do_quadgk
```
seemed ok.

To fix it, the API should be changed to take into account the different types
