### PR TITLE
bump to require 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,3 @@ julia:
   - nightly
 notifications:
   email: false
-#script: # the default script is equivalent to the following
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuadGK"); Pkg.test("QuadGK"; coverage=true)';
-after_success:
-  - julia -e 'cd(Pkg.dir("QuadGK")); Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))';
-  - julia -e 'cd(Pkg.dir("QuadGK")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-#  - julia -e 'cd(Pkg.dir("QuadGK")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,10 @@ julia:
   - nightly
 notifications:
   email: false
+#script: # the default script is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuadGK"); Pkg.test("QuadGK"; coverage=true)';
+after_success:
+  - julia -e 'cd(Pkg.dir("QuadGK")); Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))';
+  - julia -e 'cd(Pkg.dir("QuadGK")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'cd(Pkg.dir("QuadGK")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7-alpha
 DataStructures 0.5.0
-LinearAlgebra

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
-Compat 0.61.0
+julia 0.7-alpha
 DataStructures 0.5.0
+LinearAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,8 +17,7 @@ end
 
 module Test19626
     using QuadGK
-    using Compat
-    using Compat.Test
+    using Test
 
     # Define a mock physical quantity type
     struct MockQuantity <: Number

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,6 @@
 # This file contains code that was formerly part of Julia. License is MIT: http://julialang.org/license
 
-using QuadGK
-using Compat
-using Compat.Test
-
-import QuadGK: quadgk, gauss, kronrod
+using QuadGK, Test
 
 @testset "quadgk" begin
     @test quadgk(cos, 0,0.7,1)[1] ≈ sin(1)


### PR DESCRIPTION
This package hasn't changed in a while, and since https://github.com/JuliaLang/Compat.jl/commit/f5e14bd5f9b8d69209282759c1699a8eea60a826 hasn't been tagged in a Compat.jl release yet it was easier to just drop 0.6 support on `master`.