### PR TITLE
use rtol/atol instead of reltol/abstol for Julia 0.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,6 @@ module Test19626
     Base.isapprox(a::MockQuantity, b::MockQuantity) = isapprox(a.val, b.val)
 
     # Test physical quantity-valued functions
-    @test QuadGK.quadgk(x->MockQuantity(x), 0.0, 1.0, abstol=MockQuantity(0.0))[1] ≈
+    @test QuadGK.quadgk(x->MockQuantity(x), 0.0, 1.0, atol=MockQuantity(0.0))[1] ≈
         MockQuantity(0.5)
 end


### PR DESCRIPTION
DO NOT MERGE.

This is a version of #24 for the Julia 0.6 branch, so that we can tag a v0.3.0 release with the new keyword names for 0.6 users.