### PR TITLE
Do not accidentally convert numeric type to Float64

### DIFF
--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -134,7 +134,7 @@ function do_quadgk(f, s, n, ::Type{Tw}, atol, rtol, maxevals, nrm) where Tw
     # until convergence is achieved or maxevals is exceeded.
     while E > atol && E > rtol * nrm(I) && numevals < maxevals
         s = heappop!(segs, Reverse)
-        mid = (s.a + s.b) * 0.5
+        mid = (s.a + s.b) / 2
         s1 = evalrule(f, s.a, mid, x,w,gw, nrm)
         s2 = evalrule(f, mid, s.b, x,w,gw, nrm)
         heappush!(segs, s1, Reverse)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,10 @@ using QuadGK, Test
     @test quadgk(x -> exp(-x^2), -Inf,Inf)[1] ≈ sqrt(pi)
     @test quadgk(x -> [exp(-x), exp(-2x)], 0, Inf)[1] ≈ [1,0.5]
     @test quadgk(cos, 0,0.7,1, norm=abs)[1] ≈ sin(1)
+ 
+    # Test a function that is only implemented for Float32 values
+    cos32(x::Float32) = cos(20x)
+    @test quadgk(cos32, 0f0, 1f0)[1] ≈ sin(20f0)/20
 end
 
 module Test19626

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ using QuadGK, Test
  
     # Test a function that is only implemented for Float32 values
     cos32(x::Float32) = cos(20x)
-    @test quadgk(cos32, 0f0, 1f0)[1] ≈ sin(20f0)/20
+    @test quadgk(cos32, 0f0, 1f0)[1]::Float32 ≈ sin(20f0)/20
 end
 
 module Test19626


### PR DESCRIPTION
I was using a function that is implemented only for `Float32`, but using QuadGK it ends up being evaluated with a `Float64` argument.
A working example (on Julia 1.0.1):
```jl
julia> using QuadGK
julia> cos32(x::Float32) = cos(20x)
cos32 (generic function with 1 method)

julia> quadgk(cos32, 0f0, 1f0)
ERROR: MethodError: no method matching cos32(::Float64)
Closest candidates are:
  cos32(::Float32) at REPL[8]:1
Stacktrace:
 [1] evalrule(::typeof(cos32), ::Float32, ::Float64, ::Array{Float32,1}, ::Array{Float32,1}, ::Array{Float32,1}, ::typeof(LinearAlgebra.norm)) at /Users/daan/.julia/packages/QuadGK/fTRFu/src/QuadGK.jl:59
 [2] do_quadgk(::typeof(cos32), ::Array{Float32,1}, ::Int64, ::Type{Float32}, ::Float32, ::Float32, ::Int64, ::typeof(LinearAlgebra.norm)) at /Users/daan/.julia/packages/QuadGK/fTRFu/src/QuadGK.jl:138
 [3] #quadgk#13(::Float32, ::Float32, ::Missing, ::Missing, ::Int64, ::Int64, ::Function, ::Function, ::typeof(cos32), ::Float32, ::Float32) at /Users/daan/.julia/packages/QuadGK/fTRFu/src/QuadGK.jl:170
 [4] quadgk(::Function, ::Float32, ::Float32) at /Users/daan/.julia/packages/QuadGK/fTRFu/src/QuadGK.jl:169
 [5] top-level scope at none:0
```
The example function should be complicated enough to trigger subdivision of the interval (which is why I used `cos(20x)` rather than just `cos(x)`).


The culprit seems to be [this line](https://github.com/JuliaMath/QuadGK.jl/blob/master/src/QuadGK.jl#L137), which says:
```jl
mid = (s.a + s.b) * 0.5
```

In the pull request this is replaced by
```jl
mid = (s.a + s.b) / 2
```

[Elsewhere](https://github.com/JuliaMath/QuadGK.jl/blob/master/src/QuadGK.jl#L56) in the same file, the constant value `0.5` is converted to the right type using
```jl
s = convert(eltype(x), 0.5) * (b-a)
```
I think such explicit conversion is not necessary in the location that this pull request changes, as `s.a` and `s.b` are guaranteed to be floating point numbers due to the way the function `do_quadgk` is invoked. Thus, dividing by `2` preserves whatever floating point types `s.a` and `s.b` have.

The pull request also adds a simple test using the above example.