### PR TITLE
Updates for Julia 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 docs/build/
 docs/site/
+/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os:
   - linux
 julia:
   - 0.7
+  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "QuadGK"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.0.4"
+
+[deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15"
+julia = "0.7, 1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7-alpha
-DataStructures 0.5.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using QuadGK, Test
     @test quadgk(x -> exp(-x^2), -Inf,Inf)[1] ≈ sqrt(pi)
     @test quadgk(x -> [exp(-x), exp(-2x)], 0, Inf)[1] ≈ [1,0.5]
     @test quadgk(cos, 0,0.7,1, norm=abs)[1] ≈ sin(1)
- 
+
     # Test a function that is only implemented for Float32 values
     cos32(x::Float32) = cos(20x)
     @test quadgk(cos32, 0f0, 1f0)[1]::Float32 ≈ sin(20f0)/20
@@ -29,11 +29,12 @@ module Test19626
     end
 
     # Following definitions needed for quadgk to work with MockQuantity
-    import Base: +, -, *, abs, isnan, isinf, isless
+    import Base: +, -, *, abs, isnan, isinf, isless, float
     +(a::MockQuantity, b::MockQuantity) = MockQuantity(a.val+b.val)
     -(a::MockQuantity, b::MockQuantity) = MockQuantity(a.val-b.val)
     *(a::MockQuantity, b::Number) = MockQuantity(a.val*b)
     abs(a::MockQuantity) = MockQuantity(abs(a.val))
+    float(a::MockQuantity) = a
     isnan(a::MockQuantity) = isnan(a.val)
     isinf(a::MockQuantity) = isinf(a.val)
     isless(a::MockQuantity, b::MockQuantity) = isless(a.val, b.val)


### PR DESCRIPTION
In Julia 1.2, `norm` calls `float` see https://github.com/JuliaLang/julia/pull/30481