### PR TITLE
type stability

### DIFF
--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -67,7 +67,7 @@ function handle_infinities(f, s, n, atol, rtol, maxevals, nrm)
                                 map(x -> isinf(x) ? copysign(one(x), x) : 2x / (1+hypot(1,2x)), s),
                                 n, atol, rtol, maxevals, nrm)
             end
-            let (s0,si) = inf1 ? (s2,s1) : (s1,s2)
+            let (s0,si) = inf1 ? (s2,s1) : (s1,s2) # let is needed for JuliaLang/julia#15276
                 if si < 0 # x = s0 - t/(1-t)
                     return do_quadgk(t -> begin den = 1 / (1 - t);
                                                 f(s0 - t*den) * den*den; end,

--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -28,9 +28,7 @@ function do_quadgk(f, s, n, ::Type{Tw}, atol, rtol, maxevals, nrm) where Tw
         end
     end
 
-    key = rulekey(Tw,n)
-    x,w,gw = haskey(rulecache, key) ? rulecache[key] :
-       (rulecache[key] = kronrod(Tw, n))
+    x,w,gw = cachedrule(Tw,n)
     segs = Segment[]
     for i in 1:length(s) - 1
         heappush!(segs, evalrule(f, s[i],s[i+1], x,w,gw, nrm), Reverse)

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -1,49 +1,13 @@
-###########################################################################
-
-# precomputed n=7 rule in double precision (computed in 100-bit arithmetic),
-# since this is the common case.
-const xd7 = [-9.9145537112081263920685469752598e-01,
-             -9.4910791234275852452618968404809e-01,
-             -8.6486442335976907278971278864098e-01,
-             -7.415311855993944398638647732811e-01,
-             -5.8608723546769113029414483825842e-01,
-             -4.0584515137739716690660641207707e-01,
-             -2.0778495500789846760068940377309e-01,
-             0.0]
-const wd7 = [2.2935322010529224963732008059913e-02,
-             6.3092092629978553290700663189093e-02,
-             1.0479001032225018383987632254189e-01,
-             1.4065325971552591874518959051021e-01,
-             1.6900472663926790282658342659795e-01,
-             1.9035057806478540991325640242055e-01,
-             2.0443294007529889241416199923466e-01,
-             2.0948214108472782801299917489173e-01]
-const gwd7 = [1.2948496616886969327061143267787e-01,
-              2.797053914892766679014677714229e-01,
-              3.8183005050511894495036977548818e-01,
-              4.1795918367346938775510204081658e-01]
-
-# cache of T -> n -> (x,w,gw) Kronrod rules, to avoid recomputing them
-# unnecessarily for repeated integration.   We initialize it with the
-# default n=7 rule for double-precision calculations.  We use a cache
-# of caches to allow us to evaluate the cache in a type-stable way with
-# a generated function below.
-const rulecache = Dict{Type,Dict}(
-    Float64 => Dict{Int,NTuple{3,Vector{Float64}}}(7 => (xd7,wd7,gwd7)),
-    Float32 => Dict{Int,NTuple{3,Vector{Float32}}}(7 => (xd7,wd7,gwd7)))
-
-# for BigFloat rules, we need a separate cache keyed by (n,precision)
-const bigrulecache = Dict{Tuple{Int,Int}, NTuple{3,Vector{BigFloat}}}()
-
 # integration segment (a,b), estimated integral I, and estimated error E
-struct Segment
-    a::Number
-    b::Number
-    I
-    E
+struct Segment{TX,TI,TE}
+    a::TX
+    b::TX
+    I::TI
+    E::TE
 end
+Base.promote_rule(::Type{Segment{TX,TI,TE}}, ::Type{Segment{TX′,TI′,TE′}}) where {TX,TI,TE,TX′,TI′,TE′} = Segment{promote_type(TX,TX′), promote_type(TI,TI′), promote_type(TE,TE′)}
+Base.convert(::Type{T}, s::Segment) where {T<:Segment} = T(s.a,s.b,s.I,s.E)
 Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)
-
 
 # Internal routine: approximately integrate f(x) over the interval (a,b)
 # by evaluating the integration rule (x,w,gw). Return a Segment.
@@ -70,27 +34,10 @@ function evalrule(f, a,b, x,w,gw, nrm)
         Ik += f0 * w[end] +
             (f(a + (1+x[end-1])*s) + f(a + (1-x[end-1])*s)) * w[end-1]
     end
-    Ik *= s
-    Ig *= s
-    E = nrm(Ik - Ig)
+    Ik_s, Ig_s = Ik * s, Ig * s # new variable since this may change the type
+    E = nrm(Ik_s - Ig_s)
     if isnan(E) || isinf(E)
         throw(DomainError(a+s, "integrand produced $E in the interval ($a, $b)"))
     end
-    return Segment(a, b, Ik, E)
-end
-
-rulekey(::Type{BigFloat}, n) = (BigFloat, precision(BigFloat), n)
-rulekey(T,n) = (T,n)
-
-cachedrule(::Type{T}, n::Integer) where {T<:Number} = cachedrule(typeof(float(real(one(T)))), n::Integer)
-
-function cachedrule(::Type{BigFloat}, n::Integer)
-    key = (n, precision(BigFloat))
-    haskey(bigrulecache, key) ? bigrulecache[key] : (bigrulecache[key] = kronrod(BigFloat, n))
-end
-
-# use a generated function to make this type-stable
-@generated function cachedrule(::Type{T}, n::Integer) where {T<:AbstractFloat}
-    cache = haskey(rulecache, T) ? rulecache[T] : (rulecache[T] = Dict{Int,NTuple{3,Vector{T}}}())
-    :(haskey($cache, n) ? $cache[n] : ($cache[n] = kronrod($T, n)))
+    return Segment(a, b, Ik_s, E)
 end

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -39,5 +39,5 @@ function evalrule(f, a,b, x,w,gw, nrm)
     if isnan(E) || isinf(E)
         throw(DomainError(a+s, "integrand produced $E in the interval ($a, $b)"))
     end
-    return Segment(a, b, Ik_s, E)
+    return Segment(oftype(s, a), oftype(s, b), Ik_s, E)
 end

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -5,7 +5,7 @@ struct Segment{TX,TI,TE}
     I::TI
     E::TE
 end
-Base.promote_rule(::Type{Segment{TX,TI,TE}}, ::Type{Segment{TX′,TI′,TE′}}) where {TX,TI,TE,TX′,TI′,TE′} =
+Base.@pure Base.promote_rule(::Type{Segment{TX,TI,TE}}, ::Type{Segment{TX′,TI′,TE′}}) where {TX,TI,TE,TX′,TI′,TE′} =
     Segment{promote_type(TX,TX′), promote_type(TI,TI′), promote_type(TE,TE′)}
 Base.convert(::Type{T}, s::Segment) where {T<:Segment} = T(s.a,s.b,s.I,s.E)
 Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -5,7 +5,8 @@ struct Segment{TX,TI,TE}
     I::TI
     E::TE
 end
-Base.promote_rule(::Type{Segment{TX,TI,TE}}, ::Type{Segment{TX′,TI′,TE′}}) where {TX,TI,TE,TX′,TI′,TE′} = Segment{promote_type(TX,TX′), promote_type(TI,TI′), promote_type(TE,TE′)}
+Base.promote_rule(::Type{Segment{TX,TI,TE}}, ::Type{Segment{TX′,TI′,TE′}}) where {TX,TI,TE,TX′,TI′,TE′} =
+    Segment{promote_type(TX,TX′), promote_type(TI,TI′), promote_type(TE,TE′)}
 Base.convert(::Type{T}, s::Segment) where {T<:Segment} = T(s.a,s.b,s.I,s.E)
 Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)
 

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -1,73 +1,96 @@
 ###########################################################################
 
-# cache of (T,n) -> (x,w,gw) Kronrod rules, to avoid recomputing them
+# precomputed n=7 rule in double precision (computed in 100-bit arithmetic),
+# since this is the common case.
+const xd7 = [-9.9145537112081263920685469752598e-01,
+             -9.4910791234275852452618968404809e-01,
+             -8.6486442335976907278971278864098e-01,
+             -7.415311855993944398638647732811e-01,
+             -5.8608723546769113029414483825842e-01,
+             -4.0584515137739716690660641207707e-01,
+             -2.0778495500789846760068940377309e-01,
+             0.0]
+const wd7 = [2.2935322010529224963732008059913e-02,
+             6.3092092629978553290700663189093e-02,
+             1.0479001032225018383987632254189e-01,
+             1.4065325971552591874518959051021e-01,
+             1.6900472663926790282658342659795e-01,
+             1.9035057806478540991325640242055e-01,
+             2.0443294007529889241416199923466e-01,
+             2.0948214108472782801299917489173e-01]
+const gwd7 = [1.2948496616886969327061143267787e-01,
+              2.797053914892766679014677714229e-01,
+              3.8183005050511894495036977548818e-01,
+              4.1795918367346938775510204081658e-01]
+
+# cache of T -> n -> (x,w,gw) Kronrod rules, to avoid recomputing them
 # unnecessarily for repeated integration.   We initialize it with the
-# default n=7 rule for double-precision calculations.
-    const rulecache = Dict{Any,Any}( (Float64,7) => # precomputed in 100-bit arith.
-    ([-9.9145537112081263920685469752598e-01,
-      -9.4910791234275852452618968404809e-01,
-      -8.6486442335976907278971278864098e-01,
-      -7.415311855993944398638647732811e-01,
-      -5.8608723546769113029414483825842e-01,
-      -4.0584515137739716690660641207707e-01,
-      -2.0778495500789846760068940377309e-01,
-      0.0],
-     [2.2935322010529224963732008059913e-02,
-      6.3092092629978553290700663189093e-02,
-      1.0479001032225018383987632254189e-01,
-      1.4065325971552591874518959051021e-01,
-      1.6900472663926790282658342659795e-01,
-      1.9035057806478540991325640242055e-01,
-      2.0443294007529889241416199923466e-01,
-      2.0948214108472782801299917489173e-01],
-      [1.2948496616886969327061143267787e-01,
-       2.797053914892766679014677714229e-01,
-       3.8183005050511894495036977548818e-01,
-       4.1795918367346938775510204081658e-01]) )
+# default n=7 rule for double-precision calculations.  We use a cache
+# of caches to allow us to evaluate the cache in a type-stable way with
+# a generated function below.
+const rulecache = Dict{Type,Dict}(
+    Float64 => Dict{Int,NTuple{3,Vector{Float64}}}(7 => (xd7,wd7,gwd7)),
+    Float32 => Dict{Int,NTuple{3,Vector{Float32}}}(7 => (xd7,wd7,gwd7)))
 
-  # integration segment (a,b), estimated integral I, and estimated error E
-  struct Segment
-      a::Number
-      b::Number
-      I
-      E
-  end
-  Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)
+# for BigFloat rules, we need a separate cache keyed by (n,precision)
+const bigrulecache = Dict{Tuple{Int,Int}, NTuple{3,Vector{BigFloat}}}()
+
+# integration segment (a,b), estimated integral I, and estimated error E
+struct Segment
+    a::Number
+    b::Number
+    I
+    E
+end
+Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)
 
 
-  # Internal routine: approximately integrate f(x) over the interval (a,b)
-  # by evaluating the integration rule (x,w,gw). Return a Segment.
-  function evalrule(f, a,b, x,w,gw, nrm)
-      # Ik and Ig are integrals via Kronrod and Gauss rules, respectively
-      s = convert(eltype(x), 0.5) * (b-a)
-      n1 = 1 - (length(x) & 1) # 0 if even order, 1 if odd order
-      # unroll first iterationof loop to get correct type of Ik and Ig
-      fg = f(a + (1+x[2])*s) + f(a + (1-x[2])*s)
-      fk = f(a + (1+x[1])*s) + f(a + (1-x[1])*s)
-      Ig = fg * gw[1]
-      Ik = fg * w[2] + fk * w[1]
-      for i = 2:length(gw)-n1
-          fg = f(a + (1+x[2i])*s) + f(a + (1-x[2i])*s)
-          fk = f(a + (1+x[2i-1])*s) + f(a + (1-x[2i-1])*s)
-          Ig += fg * gw[i]
-          Ik += fg * w[2i] + fk * w[2i-1]
-      end
-      if n1 == 0 # even: Gauss rule does not include x == 0
-          Ik += f(a + s) * w[end]
-      else # odd: don't count x==0 twice in Gauss rule
-          f0 = f(a + s)
-          Ig += f0 * gw[end]
-          Ik += f0 * w[end] +
-                (f(a + (1+x[end-1])*s) + f(a + (1-x[end-1])*s)) * w[end-1]
-      end
-      Ik *= s
-      Ig *= s
-      E = nrm(Ik - Ig)
-      if isnan(E) || isinf(E)
-          throw(DomainError(a+s, "integrand produced $E in the interval ($a, $b)"))
-      end
-      return Segment(a, b, Ik, E)
-  end
+# Internal routine: approximately integrate f(x) over the interval (a,b)
+# by evaluating the integration rule (x,w,gw). Return a Segment.
+function evalrule(f, a,b, x,w,gw, nrm)
+    # Ik and Ig are integrals via Kronrod and Gauss rules, respectively
+    s = convert(eltype(x), 0.5) * (b-a)
+    n1 = 1 - (length(x) & 1) # 0 if even order, 1 if odd order
+    # unroll first iterationof loop to get correct type of Ik and Ig
+    fg = f(a + (1+x[2])*s) + f(a + (1-x[2])*s)
+    fk = f(a + (1+x[1])*s) + f(a + (1-x[1])*s)
+    Ig = fg * gw[1]
+    Ik = fg * w[2] + fk * w[1]
+    for i = 2:length(gw)-n1
+        fg = f(a + (1+x[2i])*s) + f(a + (1-x[2i])*s)
+        fk = f(a + (1+x[2i-1])*s) + f(a + (1-x[2i-1])*s)
+        Ig += fg * gw[i]
+        Ik += fg * w[2i] + fk * w[2i-1]
+    end
+    if n1 == 0 # even: Gauss rule does not include x == 0
+        Ik += f(a + s) * w[end]
+    else # odd: don't count x==0 twice in Gauss rule
+        f0 = f(a + s)
+        Ig += f0 * gw[end]
+        Ik += f0 * w[end] +
+            (f(a + (1+x[end-1])*s) + f(a + (1-x[end-1])*s)) * w[end-1]
+    end
+    Ik *= s
+    Ig *= s
+    E = nrm(Ik - Ig)
+    if isnan(E) || isinf(E)
+        throw(DomainError(a+s, "integrand produced $E in the interval ($a, $b)"))
+    end
+    return Segment(a, b, Ik, E)
+end
 
-  rulekey(::Type{BigFloat}, n) = (BigFloat, precision(BigFloat), n)
-  rulekey(T,n) = (T,n)
+rulekey(::Type{BigFloat}, n) = (BigFloat, precision(BigFloat), n)
+rulekey(T,n) = (T,n)
+
+cachedrule(::Type{T}, n::Integer) where {T<:Number} = cachedrule(typeof(float(real(one(T)))), n::Integer)
+
+function cachedrule(::Type{BigFloat}, n::Integer)
+    key = (n, precision(BigFloat))
+    haskey(bigrulecache, key) ? bigrulecache[key] : (bigrulecache[key] = kronrod(BigFloat, n))
+end
+
+# use a generated function to make this type-stable
+@generated function cachedrule(::Type{T}, n::Integer) where {T<:AbstractFloat}
+    cache = haskey(rulecache, T) ? rulecache[T] : (rulecache[T] = Dict{Int,NTuple{3,Vector{T}}}())
+    :(haskey($cache, n) ? $cache[n] : ($cache[n] = kronrod($T, n)))
+end

--- a/src/gausskronrod.jl
+++ b/src/gausskronrod.jl
@@ -196,3 +196,55 @@ function kronrod(::Type{T}, n::Integer) where T<:AbstractFloat
 end
 
 kronrod(N::Integer) = kronrod(Float64, N)
+
+###########################################################################
+# Type-stable cache of quadrature rule results, so that we don't
+# repeat the kronrod calculation unnecessarily.
+
+# precomputed n=7 rule in double precision (computed in 100-bit arithmetic),
+# since this is the common case.
+const xd7 = [-9.9145537112081263920685469752598e-01,
+             -9.4910791234275852452618968404809e-01,
+             -8.6486442335976907278971278864098e-01,
+             -7.415311855993944398638647732811e-01,
+             -5.8608723546769113029414483825842e-01,
+             -4.0584515137739716690660641207707e-01,
+             -2.0778495500789846760068940377309e-01,
+             0.0]
+const wd7 = [2.2935322010529224963732008059913e-02,
+             6.3092092629978553290700663189093e-02,
+             1.0479001032225018383987632254189e-01,
+             1.4065325971552591874518959051021e-01,
+             1.6900472663926790282658342659795e-01,
+             1.9035057806478540991325640242055e-01,
+             2.0443294007529889241416199923466e-01,
+             2.0948214108472782801299917489173e-01]
+const gwd7 = [1.2948496616886969327061143267787e-01,
+              2.797053914892766679014677714229e-01,
+              3.8183005050511894495036977548818e-01,
+              4.1795918367346938775510204081658e-01]
+
+# cache of T -> n -> (x,w,gw) Kronrod rules, to avoid recomputing them
+# unnecessarily for repeated integration.   We initialize it with the
+# default n=7 rule for double-precision calculations.  We use a cache
+# of caches to allow us to evaluate the cache in a type-stable way with
+# a generated function below.
+const rulecache = Dict{Type,Dict}(
+    Float64 => Dict{Int,NTuple{3,Vector{Float64}}}(7 => (xd7,wd7,gwd7)),
+    Float32 => Dict{Int,NTuple{3,Vector{Float32}}}(7 => (xd7,wd7,gwd7)))
+
+# for BigFloat rules, we need a separate cache keyed by (n,precision)
+const bigrulecache = Dict{Tuple{Int,Int}, NTuple{3,Vector{BigFloat}}}()
+
+cachedrule(::Type{T}, n::Integer) where {T<:Number} = cachedrule(typeof(float(real(one(T)))), n::Integer)
+
+function cachedrule(::Type{BigFloat}, n::Integer)
+    key = (n, precision(BigFloat))
+    haskey(bigrulecache, key) ? bigrulecache[key] : (bigrulecache[key] = kronrod(BigFloat, n))
+end
+
+# use a generated function to make this type-stable
+@generated function cachedrule(::Type{T}, n::Integer) where {T<:AbstractFloat}
+    cache = haskey(rulecache, T) ? rulecache[T] : (rulecache[T] = Dict{Int,NTuple{3,Vector{T}}}())
+    :(haskey($cache, n) ? $cache[n] : ($cache[n] = kronrod($T, n)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ using QuadGK, Test
     # Test a function that is only implemented for Float32 values
     cos32(x::Float32) = cos(20x)
     @test quadgk(cos32, 0f0, 1f0)[1]::Float32 ≈ sin(20f0)/20
+
+    # test integration of a type-unstable function where the instability is only detected
+    # during refinement of the integration interval:
+    @test quadgk(x -> x > 0.01 ? sin(10(x-0.01)) : 1im, 0,1.01, rtol=1e-4, order=3)[1] ≈ (1 - cos(10))/10+0.01im rtol=1e-4
 end
 
 module Test19626

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,4 +53,5 @@ end
     @test @inferred(quadgk(x -> exp(-x^2), 0, Inf, rtol=1e-8)) isa Tuple{Float64,Float64}
     @test @inferred(quadgk(x -> exp(-x^2), 0, 1, rtol=1e-8)) isa Tuple{Float64,Float64}
     @test @inferred(quadgk(x -> 1, 0, 1im)) === (1.0im, 0.0)
+    @test @inferred(quadgk(x -> sin(10x), 0,1))[1] ≈ (1 - cos(10))/10
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,3 +46,8 @@ module Test19626
     @test QuadGK.quadgk(x->MockQuantity(x), 0.0, 1.0, atol=MockQuantity(0.0))[1] ≈
         MockQuantity(0.5)
 end
+
+@testset "inference" begin
+    @test @inferred(QuadGK.cachedrule(Float16, 3)) == (Float16[-0.96, -0.7744, -0.434, 0.0], Float16[0.1047, 0.269, 0.4014, 0.4504], Float16[0.555, 0.8896])
+    @test @inferred(QuadGK.cachedrule(Complex{BigFloat}, 3)) isa NTuple{3,Vector{BigFloat}}
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,4 +50,7 @@ end
 @testset "inference" begin
     @test @inferred(QuadGK.cachedrule(Float16, 3)) == (Float16[-0.96, -0.7744, -0.434, 0.0], Float16[0.1047, 0.269, 0.4014, 0.4504], Float16[0.555, 0.8896])
     @test @inferred(QuadGK.cachedrule(Complex{BigFloat}, 3)) isa NTuple{3,Vector{BigFloat}}
+    @test @inferred(quadgk(x -> exp(-x^2), 0, Inf, rtol=1e-8)) isa Tuple{Float64,Float64}
+    @test @inferred(quadgk(x -> exp(-x^2), 0, 1, rtol=1e-8)) isa Tuple{Float64,Float64}
+    @test @inferred(quadgk(x -> 1, 0, 1im)) === (1.0im, 0.0)
 end


### PR DESCRIPTION
Makes the `quadgk` function type-stable.  Closes #21. Closes #19. Closes #15.  Closes #20.

Also fixes handling of some other other number types, and in particular fixes dimensionful types (#17).  Mostly supersedes https://github.com/PainterQubits/UnitfulIntegration.jl, cc @ajkeller34:
```jl
julia> using Unitful, QuadGK, Test

julia> @inferred quadgk(x -> x^2, 0u"m", 1u"m")
(0.3333333333333333 m^3, 5.551115123125783e-17 m^3)
```

It still doesn't completely address #13, because it only works if `real(one(T))` returns the underlying real numeric type for computing the quadrature weights etc.   This doesn't work for dual numbers (ForwardDiff.jl) or measurements (JuliaPhysics/Measurements.jl#31), and in general I haven't been able to think of a way to do this that works across packages.