### PR TITLE
Add 0.17 as a compatible version for DataStructures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15"
+DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.17"
 julia = "0.7, 1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.17"
+DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
 julia = "0.7, 1"
 
 [extras]


### PR DESCRIPTION
`QuadGK` holds package `DataStrctures` to `v0.15`, which is incompatible with requirement for new versions of `DifferentialEquations` (and maybe some other packages). It seems to be OK to add `v0.17` to the compatible list. The tests still pass. 

This is related to #39.