### PR TITLE
Cauchy principal value integrals

### DIFF
--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -23,7 +23,7 @@ and returns the approximate `integral = 0.746824132812427` and error estimate
 """
 module QuadGK
 
-export quadgk, gauss, kronrod
+export quadgk, gauss, kronrod, cauchy
 
 using DataStructures, LinearAlgebra
 import Base.Order.Reverse

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -27,10 +27,12 @@ export quadgk, gauss, kronrod
 
 using DataStructures, LinearAlgebra
 import Base.Order.Reverse
+using FastTransforms: clenshawcurtisnodes, clenshawcurtisweights
 
 include("gausskronrod.jl")
 include("evalrule.jl")
 include("adapt.jl")
 include("weightedgauss.jl")
+include("cauchy.jl")
 
 end # module QuadGK

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -28,7 +28,7 @@ export quadgk, gauss, kronrod
 using DataStructures, LinearAlgebra
 import Base.Order.Reverse
 using FastTransforms: clenshawcurtisnodes, clenshawcurtisweights
-using GeneralizedGenerated: mk_function
+
 include("gausskronrod.jl")
 include("evalrule.jl")
 include("adapt.jl")

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -28,7 +28,7 @@ export quadgk, gauss, kronrod
 using DataStructures, LinearAlgebra
 import Base.Order.Reverse
 using FastTransforms: clenshawcurtisnodes, clenshawcurtisweights
-
+using GeneralizedGenerated: mk_function
 include("gausskronrod.jl")
 include("evalrule.jl")
 include("adapt.jl")

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -27,7 +27,6 @@ export quadgk, gauss, kronrod, cauchy
 
 using DataStructures, LinearAlgebra
 import Base.Order.Reverse
-using FastTransforms: clenshawcurtisnodes, clenshawcurtisweights
 
 include("gausskronrod.jl")
 include("evalrule.jl")

--- a/src/cauchy.jl
+++ b/src/cauchy.jl
@@ -1,0 +1,97 @@
+# Internal routine: integrate f over the interval (s[1], s[2]) using 
+# h-adaptive integration
+function do_cauchy(f::F, s::NTuple{2,T}, c::T, n_gk, n_cc, atol, rtol, maxevals, nrm) where {T,F}
+  gk_rule = cachedrule(eltype(s), n_gk)
+  cc_rule = clenshawcurtisnodes(eltype(s), n_cc)
+
+  seg = evalrule_cauchy(f, s[1], s[2], c, gk_rule, cc_rule, nrm)
+  I = seg.I
+  E = seg.E
+  numevals = (2n_gk+1)
+
+  # logic here is mainly to handle dimensionful quantities: we
+  # don't know the correct type of atol, in particular, until
+  # this point where we have the type of E from f.  Also, follow
+  # Base.isapprox in that if atol≠0 is supplied by the user, rtol
+  # defaults to zero.
+  atol_ = something(atol, zero(E))
+  rtol_ = something(rtol, iszero(atol_) ? sqrt(eps(one(eltype(gk_rule[1])))) : zero(eltype(gk_rule[1])))
+
+  if E ≤ atol_ || E ≤ rtol_ * nrm(I) || numevals ≥ maxevals
+    return (I, E)
+  end
+
+  return adapt_cauchy(f, heapify!([seg], Reverse), I, E, numevals, gk_rule, cc_rule, atol_, rtol_, maxevals, nrm)
+end
+
+function adapt_cauchy(f, seg::T, I, E, numevals, gk_rule, cc_rule, atol, rtol, maxevals, nrm) where {T}
+end
+
+# When close to the singularity c, use a special modified Clenshaw-Curtis rule
+# otherwise, stick with Gauss-Kronrod
+function evalrule_cauchy(f, a, b, c, rk_rule, cc_rule, nrm)
+
+  # Determine how close we are to the singularity
+  d = (2 * c - b - a) / (b - a)
+
+  # Use Gauss-Kronrod
+  if abs(d) > 1.1
+    return evalrule(x -> f(x) / (x - c), a, b, rk_rule..., nrm)
+
+  # Use modified Clenshaw-Curtis
+  else
+    f_nodes = f.(b .+ (1 .- cc_rule) .* (a-b)/2)
+
+    cheb = clenshawcurtisweights(f_nodes)
+    cheb₂ = clenshawcurtisweights(f_nodes[1:2:end])
+
+    μ = compute_moments(d, length(cc_rule))
+
+    I = cheb' * μ
+    I₂ = cheb₂' * μ[1:length(cheb₂)]
+    
+    E = abs(I - I₂)
+    return Segment(oftype(d, a), oftype(d, b), I, E)
+  end
+end
+
+function compute_moments(cc::T, n::Int) where T
+    μ = zeros(T, n)
+    n > 0 && (μ[1] = log(abs((1.0 - cc) / (1.0 + cc))))
+    if n > 1
+        μ[2] = μ[1] * cc + 2
+        for i=2:n
+          cst = isodd(i) ? T(4)/T(1 - (i-1)^2) : 0.0
+          @inbounds μ[i+1] = 2cc * μ[i] - μ[i-1] + cst
+        end
+    end
+    μ
+end
+
+
+"""
+This function computes the Cauchy principal value of the integral of f over 
+(a,b), with a singularity at c
+"""
+cauchy(f, a, c, b; kws...) = cauchy(f, promote(a,c,b)..., kws...)
+
+function cauchy(f, a::T, c::T, b::T;
+                atol=nothing, rtol=nothing, maxevals=10^7, order_gk=7, order_cc=25, norm=norm) where {T}
+
+  if c == a || c == b
+    error("cannot integrate with singularity on endpoint")
+  end
+
+  if iseven(order_cc)
+      error("order_cc must be an odd number")
+  end
+  
+  handle_infinities(f, (a, b)) do f, s, _
+    if >(s...)
+      s = reverse(s)
+      f = x -> -f(x)
+    end
+    
+    do_cauchy(f, s, c, order_gk, order_cc, atol, rtol, maxevals, norm)
+  end
+end

--- a/src/cauchy.jl
+++ b/src/cauchy.jl
@@ -101,7 +101,7 @@ cachedpoints(::Type{T}, n::Integer) where T<:Number = n == 1 ? error() : T[π * 
 
 function chebyshevcoeffs(f::Vector{T}, p::Vector) where T
   n = length(f)
-  out = T[2 / n * sum(fk * cos(j * pk) for (fk, pk) in zip(f, p)) for j in 0:n-1]
+  out = T[2.0 / n * sum(f[i] * cos(j * p[i]) for i in 1:n) for j in 0:n-1]
   out[1] *= 0.5; out[n] *= 0.5
   return out
 end

--- a/src/cauchy.jl
+++ b/src/cauchy.jl
@@ -1,13 +1,13 @@
 # Internal routine: integrate f over the interval (s[1], s[2]) using 
 # h-adaptive integration
-function do_cauchy(f::F, s::NTuple{2,T}, c::T, n_gk, n_cc, atol, rtol, maxevals, nrm) where {T,F}
-  gk_rule = cachedrule(eltype(s), n_gk)
-  cc_rule = clenshawcurtisnodes(eltype(s), n_cc)
+function do_cauchy(segs::NTuple{N,T}, n_gk, n_cc, atol, rtol, maxevals, nrm) where {T,N}
+  gk_rule = cachedrule(eltype(atol), n_gk)
+  cc_rule = clenshawcurtisnodes(eltype(atol), n_cc)
 
-  seg = evalrule_cauchy(f, s[1], s[2], c, gk_rule, cc_rule, nrm)
-  I = seg.I
-  E = seg.E
-  numevals = (2n_gk+1)
+  segs = ntuple(i -> evalrule_cauchy(segs[i].f, segs[i].a, segs[i].b, segs[i].c, gk_rule, cc_rule, nrm), Val{N}())
+  I = sum(s -> s.I, segs)
+  E = sum(s -> s.E, segs)
+  numevals = (2n_cc+1) * N # Because it will definitely be a Clenshaw-Curtis evaluation
 
   # logic here is mainly to handle dimensionful quantities: we
   # don't know the correct type of atol, in particular, until
@@ -20,53 +20,54 @@ function do_cauchy(f::F, s::NTuple{2,T}, c::T, n_gk, n_cc, atol, rtol, maxevals,
   if E ≤ atol_ || E ≤ rtol_ * nrm(I) || numevals ≥ maxevals
     return (I, E)
   end
-  return adapt_cauchy(f, heapify!([seg], Reverse), c, I, E, numevals, n_gk, gk_rule, cc_rule, atol_, rtol_, maxevals, nrm)
+  return adapt_cauchy(heapify!(collect(segs), Reverse), I, E, numevals, n_gk, gk_rule, cc_rule, atol_, rtol_, maxevals, nrm)
 end
 
-function adapt_cauchy(f, segs::T, c, I, E, numevals, n_gk, gk_rule, cc_rule, atol, rtol, maxevals, nrm) where {T}
-    # Pop the biggest-error segment and subdivide (h-adaptation)
-    # until convergence is achieved or maxevals is exceeded.
-    while E > atol && E > rtol * nrm(I) && numevals < maxevals
-        s = heappop!(segs, Reverse)
-        
-        a1 = s.a
-        b1 = 0.5*(s.a + s.b)
-        a2 = b1
-        b2 = s.b
-        
-        if c > a1 && c <= b1
-          b1 = 0.5 * (c + b2) ;
-          a2 = b1;
-        elseif (c > b1 && c < b2)
-          b1 = 0.5 * (a1 + c) ;
-          a2 = b1;
-        end
-        
-        s1 = evalrule_cauchy(f, a1, b1, c, gk_rule,cc_rule, nrm)
-        s2 = evalrule_cauchy(f, a2, b2, c, gk_rule,cc_rule, nrm)
-
-        I = (I - s.I) + s1.I + s2.I
-        E = (E - s.E) + s1.E + s2.E
-        numevals += 4n_gk+2
-        # handle type-unstable functions by converting to a wider type if needed
-        Tj = promote_type(typeof(s1), promote_type(typeof(s2), T))
-        if Tj !== T
-            return adapt_cauchy(f, heappush!(heappush!(Vector{Tj}(segs), s1, Reverse), s2, Reverse),
-                         c, I, E, numevals, n_gk, gk_rule, cc_rule, atol, rtol, maxevals, nrm)
-        end
-        
-        heappush!(segs, s1, Reverse)
-        heappush!(segs, s2, Reverse)
+function adapt_cauchy(seg::T, I, E, numevals, n_gk, gk_rule, cc_rule, atol, rtol, maxevals, nrm) where {T}
+  # Pop the biggest-error segment and subdivide (h-adaptation)
+  # until convergence is achieved or maxevals is exceeded.
+  while E > atol && E > rtol * nrm(I) && numevals < maxevals
+    s = heappop!(seg, Reverse)
+    
+    a1 = s.a
+    b1 = 0.5 * (s.a + s.b)
+    a2 = b1
+    b2 = s.b
+    
+    if s.c > a1 && s.c <= b1
+      b1 = 0.5 * (s.c + b2)
+      a2 = b1
+    elseif (s.c > b1 && s.c < b2)
+      b1 = 0.5 * (a1 + s.c)
+      a2 = b1
     end
     
-    # re-sum (paranoia about accumulated roundoff)
-    I = segs[1].I
-    E = segs[1].E
-    for i in 2:length(segs)
-        I += segs[i].I
-        E += segs[i].E
+    s1 = evalrule_cauchy(s.f, a1, b1, s.c, gk_rule,cc_rule, nrm)
+    s2 = evalrule_cauchy(s.f, a2, b2, s.c, gk_rule,cc_rule, nrm)
+    numevals += 4*length(cc_rule)+2
+
+    I = (I - s.I) + s1.I + s2.I
+    E = (E - s.E) + s1.E + s2.E
+    
+    # handle type-unstable functions by converting to a wider type if needed
+    Tj = promote_type(typeof(s1), promote_type(typeof(s2), T))
+    if Tj !== T
+      return adapt_cauchy(heappush!(heappush!(Vector{Tj}(seg), s1, Reverse), s2, Reverse),
+                  I, E, numevals, n_gk, gk_rule, cc_rule, atol, rtol, maxevals, nrm)
     end
-    return (I, E)
+    
+    heappush!(seg, s1, Reverse)
+    heappush!(seg, s2, Reverse)
+  end
+  
+  # re-sum (paranoia about accumulated roundoff)
+  I = seg[1].I
+  E = seg[1].E
+  for i in 2:length(seg)
+      I += seg[i].I
+      E += seg[i].E
+  end
+  return (I, E)
 end
 
 # When close to the singularity c, use a special modified Clenshaw-Curtis rule
@@ -78,7 +79,8 @@ function evalrule_cauchy(f, a, b, c, rk_rule, cc_rule, nrm)
 
   # Use Gauss-Kronrod
   if abs(d) > 1.1
-    return evalrule(x -> f(x) / (x - c), a, b, rk_rule..., nrm)
+    seg = evalrule(x -> f(x) / (x - c), a, b, rk_rule..., nrm)
+    I, E = seg.I, seg.E
 
   # Use modified Clenshaw-Curtis
   else
@@ -89,25 +91,52 @@ function evalrule_cauchy(f, a, b, c, rk_rule, cc_rule, nrm)
 
     μ = compute_moments(d, length(cc_rule))
 
-    I = cheb' * μ
     I₂ = cheb₂' * μ[1:length(cheb₂)]
-    
+    I = cheb' * μ
     E = abs(I - I₂)
-    return Segment(oftype(d, a), oftype(d, b), I, E)
   end
+  return CauchySegment(f, c, oftype(d, a), oftype(d, b), I, E)
 end
 
 function compute_moments(cc::T, n::Int) where T
-    μ = zeros(T, n)
-    n > 0 && (μ[1] = log(abs((1.0 - cc) / (1.0 + cc))))
-    if n > 1
-        μ[2] = μ[1] * cc + 2
-        for i=2:n
-          cst = isodd(i) ? T(4)/T(1 - (i-1)^2) : 0.0
-          @inbounds μ[i+1] = 2cc * μ[i] - μ[i-1] + cst
-        end
+  μ = zeros(T, n)
+  n > 0 && (μ[1] = log(abs((1.0 - cc) / (1.0 + cc))))
+  if n > 1
+    μ[2] = μ[1] * cc + 2
+    for i=2:n
+      cst = isodd(i) ? T(4)/T(1 - (i-1)^2) : 0.0
+      @inbounds μ[i+1] = 2cc * μ[i] - μ[i-1] + cst
     end
-    μ
+  end
+  μ
+end
+
+struct CauchySegment{TX,TI,TE}
+  f::Any
+  c::TX
+  a::TX
+  b::TX
+  I::TI
+  E::TE
+end
+Base.isless(i::CauchySegment, j::CauchySegment) = isless(i.E, j.E)
+
+function gen_funcs(f::Function, cs::NTuple{N,T}) where {N,T}
+  if N == 1
+    return (f, )
+  end
+
+  funcs = tuple()
+  for c in cs
+    non_singularities = tuple(setdiff(cs, c)...)
+    ex = :(*())
+    for ns in non_singularities
+      push!(ex.args, :(x - $ns))
+    end
+    funcs = tuple(funcs..., mk_function(:(x -> $f(x) / $ex)))
+  end
+
+  return funcs
 end
 
 
@@ -115,25 +144,32 @@ end
 This function computes the Cauchy principal value of the integral of f over 
 (a,b), with a singularity at c
 """
-cauchy(f, a, c, b; kws...) = cauchy(f, promote(a,c,b)..., kws...)
+cauchy(f, a, b, cs...; kws...) = cauchy(f, promote(a,b,cs...)..., kws...)
 
-function cauchy(f, a::T, c::T, b::T;
-                atol=eps(T), rtol=nothing, maxevals=10^7, order_gk=7, order_cc=25, norm=norm) where {T}
+function cauchy(f, a::T, b::T, cs::Vararg{T,N};
+                atol=sqrt(eps(T)), rtol=nothing, maxevals=10^7, order_gk=7, order_cc=25, norm=norm) where {T,N}
+  
+  if cs != tuple(unique(cs)...)
+    error("can only integrate simple poles")
+  end
 
-  if c == a || c == b
-    error("cannot integrate with singularity on endpoint")
+  cs = tuple(sort([cs...])...)
+
+  if cs[1] ≤ a || cs[end] ≥ b
+    error("singularities must lie inside the integration boundaries")
   end
 
   if iseven(order_cc)
-      error("order_cc must be an odd number")
+    error("order_cc must be an odd number")
   end
   
-  handle_infinities(f, (a, b)) do f, s, _
-    if >(s...)
-      s = reverse(s)
-      f = x -> -f(x)
-    end
-    
-    do_cauchy(f, s, c, order_gk, order_cc, atol, rtol, maxevals, norm)
-  end
+  # Create segments with singularities in between
+  segs = tuple(a, ntuple(i -> 0.5 * (cs[i] + cs[i+1]), Val{N-1}())..., b)
+  segs = ntuple(i -> (segs[i], segs[i+1]), Val{N}())
+
+  funs = gen_funcs(f, cs)
+
+  segs = (CauchySegment(f, c, s[1], s[2], 0.0, 0.0) for (f, c, s) in zip(funs, cs, segs))
+
+  do_cauchy(tuple(segs...), order_gk, order_cc, atol, rtol, maxevals, norm)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,3 +79,14 @@ end
     @test x ≈ x′
     @test w ≈ w′
 end
+
+@testset "cauchy" begin
+    @test QuadGK.cauchy(x -> x, 0.0,1.0,5.0)[1] ≈ 5+log(4)
+    @test QuadGK.cauchy(x -> x, 0.0,1.0,2.0,3.0,4.0)[1]  ≈ -log(3)
+    @test QuadGK.cauchy(x -> x/(x+1), 0.0,1.0,2.0)[1] ≈ 0.5*log(3)
+    @test QuadGK.cauchy(x -> exp(im*x), 0.0,1.0,2.0)[1] ≈ -1.592202905863904 + im*1.022341728924397
+    @test QuadGK.cauchy(x -> cos(x), 0.0,1.0,2.0)[1] + im*QuadGK.cauchy(x -> sin(x), 0.0,1.0,2.0)[1] ≈ QuadGK.cauchy(x -> exp(im*x), 0.0,1.0,2.0)[1]
+    @test QuadGK.cauchy(x ->x+im*x^2, 0,1,2)[1] ≈ 2+im*4
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,12 +81,12 @@ end
 end
 
 @testset "cauchy" begin
-    @test QuadGK.cauchy(x -> x, 0.0,1.0,5.0)[1] ≈ 5+log(4)
-    @test QuadGK.cauchy(x -> x, 0.0,1.0,2.0,3.0,4.0)[1]  ≈ -log(3)
-    @test QuadGK.cauchy(x -> x/(x+1), 0.0,1.0,2.0)[1] ≈ 0.5*log(3)
-    @test QuadGK.cauchy(x -> exp(im*x), 0.0,1.0,2.0)[1] ≈ -1.592202905863904 + im*1.022341728924397
-    @test QuadGK.cauchy(x -> cos(x), 0.0,1.0,2.0)[1] + im*QuadGK.cauchy(x -> sin(x), 0.0,1.0,2.0)[1] ≈ QuadGK.cauchy(x -> exp(im*x), 0.0,1.0,2.0)[1]
-    @test QuadGK.cauchy(x ->x+im*x^2, 0,1,2)[1] ≈ 2+im*4
+    @test cauchy(x -> x, 0.0,1.0,5.0)[1] ≈ 5+log(4)
+    @test cauchy(x -> x, 0.0,1.0,2.0,3.0,4.0)[1]  ≈ -log(3)
+    @test cauchy(x -> x/(x+1), 0.0,1.0,2.0)[1] ≈ 0.5*log(3)
+    @test cauchy(x -> exp(im*x), 0.0,1.0,2.0)[1] ≈ -1.592202905863904 + im*1.022341728924397
+    @test cauchy(x -> cos(x), 0.0,1.0,2.0)[1] + im*QuadGK.cauchy(x -> sin(x), 0.0,1.0,2.0)[1] ≈ QuadGK.cauchy(x -> exp(im*x), 0.0,1.0,2.0)[1]
+    @test cauchy(x ->x+im*x^2, 0,1,2)[1] ≈ 2+im*4
 end
 
 


### PR DESCRIPTION
Here's an implementation that can evaluate Cauchy principal value integrals using the method presented [here](https://www.sciencedirect.com/science/article/pii/0771050X75900091). It does not support infinite boundaries due to [this already known problem](https://github.com/JuliaMath/QuadGK.jl/pull/42#issuecomment-563439264).

I tried to stick to / reuse most of the base code of `do_quadgk` but some fundamental changes were needed to account for the evaluation of a function with multiple simple poles.
One could argue that that is a bit redundant, since the user could just split the the integral into several 1-simple-poled functions, but I decided to keep it anyway.

I am sure certain things could be polished and a downside is that uses the FastTransforms library for [this](url) computation.

Some parts could still be polished (such as supporting functions beyond C -> C) but I think I should hear your feedback regarding bigger changes one should worry about first