### PR TITLE
quadgk! function for more in-place operation on array-valued integrands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ which computes the integral of exp(–x²) from x=0 to x=1 to a relative toleran
 
 For more information, see the [documentation](https://JuliaMath.github.io/QuadGK.jl/stable).
 
+## In-place operations for array-valued integrands
+
+For integrands whose values are *small* arrays whose length is known at compile-time,
+it is usually most efficient to modify your integrand to return
+an `SVector` from the [StaticArrays.jl package](https://github.com/JuliaArrays/StaticArrays.jl).
+
+However, for integrands that return large or variabley-length arrays, we also provide a function
+`quadgk!(f!, result, a,b...)` in order to exploit in-place operations where possible.   The
+`result` argument is used to store the estimated integral `I` in-place, and the integrand function
+is now of the form `f!(r, x)` and should write `f(x)` in-place into the result array `r`.
+
 ## Gaussian quadrature and arbitrary weight functions
 
 If you are computing many similar integrals of smooth functions, you may not need an adaptive

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -23,10 +23,30 @@ and returns the approximate `integral = 0.746824132812427` and error estimate
 """
 module QuadGK
 
-export quadgk, gauss, kronrod
+export quadgk, quadgk!, gauss, kronrod
 
 using DataStructures, LinearAlgebra
 import Base.Order.Reverse
+
+# an in-place integrand function f!(result, x) and
+# temporary mutable data (e.g. arrays) of type R for evalrule
+struct InplaceIntegrand{F,R,RI}
+    f!::F
+
+    # temporary arrays for evalrule
+    fg::R
+    fk::R
+    Ig::R
+    Ik::R
+    fx::R
+    Idiff::RI
+
+    # final result array
+    I::RI
+end
+
+InplaceIntegrand(f!::F, I::RI, fx::R) where {F,RI,R} =
+    InplaceIntegrand{F,R,RI}(f!, similar(fx), similar(fx), similar(fx), similar(fx), fx, similar(I), I)
 
 include("gausskronrod.jl")
 include("evalrule.jl")

--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -194,6 +194,10 @@ types supporting in-place operations).  In particular, there are two differences
    into the `result` argument, so that `I === result`.
 
 Otherwise, the behavior is identical to `quadgk`.
+
+For integrands whose values are *small* arrays whose length is known at compile-time,
+it is usually more efficient to use `quadgk` and modify your integrand to return
+an `SVector` from the [StaticArrays.jl package](https://github.com/JuliaArrays/StaticArrays.jl).
 """
 function quadgk!(f!, result, a::T,b::T,c::T...; atol=nothing, rtol=nothing, maxevals=10^7, order=7, norm=norm) where {T}
     fx = result / oneunit(T) # pre-allocate array of correct type for integrand evaluations

--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -8,7 +8,14 @@ function do_quadgk(f::F, s::NTuple{N,T}, n, atol, rtol, maxevals, nrm) where {T,
 
     @assert N ≥ 2
     segs = ntuple(i -> evalrule(f, s[i],s[i+1], x,w,gw, nrm), Val{N-1}())
-    I = sum(s -> s.I, segs)
+    if f isa InplaceIntegrand
+        I = f.I .= segs[1].I
+        for i = 2:length(segs)
+            I .+= segs[i].I
+        end
+    else
+        I = sum(s -> s.I, segs)
+    end
     E = sum(s -> s.E, segs)
     numevals = (2n+1) * (N-1)
 
@@ -37,7 +44,11 @@ function adapt(f, segs::Vector{T}, I, E, numevals, x,w,gw,n, atol, rtol, maxeval
         mid = (s.a + s.b) / 2
         s1 = evalrule(f, s.a, mid, x,w,gw, nrm)
         s2 = evalrule(f, mid, s.b, x,w,gw, nrm)
-        I = (I - s.I) + s1.I + s2.I
+        if f isa InplaceIntegrand
+            I .= (I .- s.I) .+ s1.I .+ s2.I
+        else
+            I = (I - s.I) + s1.I + s2.I
+        end
         E = (E - s.E) + s1.E + s2.E
         numevals += 4n+2
 
@@ -53,11 +64,20 @@ function adapt(f, segs::Vector{T}, I, E, numevals, x,w,gw,n, atol, rtol, maxeval
     end
 
     # re-sum (paranoia about accumulated roundoff)
-    I = segs[1].I
-    E = segs[1].E
-    for i in 2:length(segs)
-        I += segs[i].I
-        E += segs[i].E
+    if f isa InplaceIntegrand
+        I .= segs[1].I
+        E = segs[1].E
+        for i in 2:length(segs)
+            I .+= segs[i].I
+            E += segs[i].E
+        end
+    else
+        I = segs[1].I
+        E = segs[1].E
+        for i in 2:length(segs)
+            I += segs[i].I
+            E += segs[i].E
+        end
     end
     return (I, E)
 end
@@ -158,3 +178,25 @@ quadgk(f, a::T,b::T,c::T...;
     handle_infinities(f, (a, b, c...)) do f, s, _
         do_quadgk(f, s, order, atol, rtol, maxevals, norm)
     end
+
+"""
+    quadgk!(f!, result, a,b,c...; rtol=sqrt(eps), atol=0, maxevals=10^7, order=7, norm=norm)
+
+Like `quadgk`, but make use of in-place operations for array-valued integrands (or other mutable
+types supporting in-place operations).  In particular, there are two differences from `quadgk`:
+
+1. The function `f!` should be of the form `f!(y, x) = y .= f(x)`.  That is, it writes the
+   return value of the integand `f(x)` in-place into its first argument `y`.   (The return
+   value of `f!` is ignored.)
+
+2. Like `quadgk`, the return value is a tuple `(I,E)` of the estimated integral `I` and the
+   estimated error `E`.   However, in `quadgk!` the estimated integral is written in-place
+   into the `result` argument, so that `I === result`.
+
+Otherwise, the behavior is identical to `quadgk`.
+"""
+function quadgk!(f!, result, a::T,b::T,c::T...; atol=nothing, rtol=nothing, maxevals=10^7, order=7, norm=norm) where {T}
+    fx = result / oneunit(T) # pre-allocate array of correct type for integrand evaluations
+    f = InplaceIntegrand(f!, result, fx)
+    return quadgk(f, a, b, c...; atol=atol, rtol=rtol, maxevals=maxevals, order=order, norm=norm)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,3 +79,15 @@ end
     @test x ≈ x′
     @test w ≈ w′
 end
+
+≅(x::Tuple, y::Tuple) = all(a -> isapprox(a[1],a[2]), zip(x,y))
+
+@testset "inplace" begin
+    I = [0., 0.]
+    I′,E′ = quadgk!(I, 0, 1) do r,x
+        r[1] = cos(100x)
+        r[2] = sin(30x)
+    end
+    @test quadgk(x -> [cos(100x), sin(30x)], 0, 1) ≅ (I′,E′) ≅ ([-0.005063656411097513, 0.028191618337080532], 4.2100180879009775e-10)
+    @test I === I′ # result is written in-place to I
+end


### PR DESCRIPTION
Closes #12.

@ChrisRackauckas, this cuts down on the allocations by a factor of 3–10 for array-valued integrands.  Is that what you had in mind?

There's more code duplication than I would ideally like, but it isn't too bad.