### PR TITLE
Inplace method with Inf domain

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,13 @@ end
     @test I === I′ # result is written in-place to I
 end
 
+@testset "inplace Inf" begin
+    f!(v, x) = v .= exp(-x^2)
+    @test quadgk!(f!, [0.], 1., Inf)[1] ≈ quadgk(x -> [exp(-x^2)], 1., Inf)[1]
+    @test quadgk!(f!, [0.], -Inf, 1.)[1] ≈ quadgk(x -> [exp(-x^2)], -Inf, 1.)[1]
+    @test quadgk!(f!, [0.], -Inf, Inf)[1] ≈ quadgk(x -> [exp(-x^2)], -Inf, Inf)[1]
+end
+
 # This is enough for allocation currently caused by the do-lambda in quadgk(...)
 const smallallocbytes = 500
 


### PR DESCRIPTION
Fixes #50 

```julia
using QuadGK
using BenchmarkTools
using Test

f(x) = 1 / x^2
g(x) = [f(x)]
f!(y, x) = y .= f(x)
@btime quadgk($f, 1., 100.)          # 1.187 μs (2 allocations: 368 bytes)
@btime quadgk($g, 1., 100.)          # 27.081 μs (728 allocations: 45.73 KiB)
@btime quadgk!($f!, [0.], 1., 100.)  # 4.218 μs (39 allocations: 2.67 KiB)

@btime quadgk($f, 1., Inf)           # 135.747 ns (0 allocations: 0 bytes)
@btime quadgk($g, 1., Inf)           # 2.906 μs (77 allocations: 4.81 KiB)
@btime quadgk!($f!, [0.], 1., Inf)   # 729.695 ns (14 allocations: 896 bytes)
```