### PR TITLE
avoid integrand evaluations at endpoints

### DIFF
--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -12,7 +12,7 @@ function do_quadgk(f::F, s::NTuple{N,T}, n, atol, rtol, maxevals, nrm, segbuf) w
     else
         segs = ntuple(Val{N-1}()) do i
             seg = evalrule(f, s[i],s[i+1], x,w,gw, nrm)
-            seg === nothing ? throw(DomainError((s[i] + s[i+1])/2, "integrand evaluated at an endpoint of the initial interval ($(s[i]), $(s[i+1]))")) : seg
+            seg === nothing ? throw(DomainError((s[i] + s[i+1])/2, "roundoff error detected near endpoint of the initial interval ($(s[i]), $(s[i+1]))")) : seg
         end
     end
     if f isa InplaceIntegrand

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -73,8 +73,8 @@ function evalrules(f::BatchIntegrand, s::NTuple{N}, x,w,gw, nrm) where {N}
         o = (i-1)*m
         f.x[l+o] = a + c
         for j in 1:l-1
-            f.x[j+o] = a + (1 + x[j]) * c
-            f.x[m+1-j+o] = a + (1 - x[j]) * c
+            (f.x[j+o] = a + (1 + x[j]) * c) == a && throw(DomainError(a, "integrand evaluated at an endpoint of the initial interval ($a, $b)"))
+            (f.x[m+1-j+o] = a + (1 - x[j]) * c) == b && throw(DomainError(b, "integrand evaluated at an endpoint of the initial interval ($a, $b)"))
         end
     end
     f.f!(f.y, f.x)  # evaluate integrand
@@ -114,8 +114,8 @@ function refine(f::BatchIntegrand, segs::Vector{T}, I, E, numevals, x,w,gw,n, at
             o = (2i-j)*m
             f.x[l+o] = a + c
             for k in 1:l-1
-                f.x[k+o] = a + (1 + x[k]) * c
-                f.x[m+1-k+o] = a + (1 - x[k]) * c
+                (f.x[k+o] = a + (1 + x[k]) * c) == a && return segs # early return if integrand evaluated at endpoints
+                (f.x[m+1-k+o] = a + (1 - x[k]) * c) == b && return segs
             end
         end
     end

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -73,8 +73,8 @@ function evalrules(f::BatchIntegrand, s::NTuple{N}, x,w,gw, nrm) where {N}
         o = (i-1)*m
         f.x[l+o] = a + c
         for j in 1:l-1
-            (f.x[j+o] = a + (1 + x[j]) * c) == a && throw(DomainError(a, "integrand evaluated at an endpoint of the initial interval ($a, $b)"))
-            (f.x[m+1-j+o] = a + (1 - x[j]) * c) == b && throw(DomainError(b, "integrand evaluated at an endpoint of the initial interval ($a, $b)"))
+            (f.x[j+o] = a + (1 + x[j]) * c) == a && throw(DomainError(a, "roundoff error detected near endpoint of the initial interval ($a, $b)"))
+            (f.x[m+1-j+o] = a + (1 - x[j]) * c) == b && throw(DomainError(b, "roundoff error detected near endpoint of the initial interval ($a, $b)"))
         end
     end
     f.f!(f.y, f.x)  # evaluate integrand

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -15,9 +15,6 @@ Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)
 function evalrule(f::F, a,b, x,w,gw, nrm) where {F}
     # Ik and Ig are integrals via Kronrod and Gauss rules, respectively
     s = convert(eltype(x), 0.5) * (b-a)
-
-    (a == a + (1+x[1])*s || b == a + (1-x[1])*s) && return nothing  # check for endpoint roundoff
-
     n1 = 1 - (length(x) & 1) # 0 if even order, 1 if odd order
     if n1 == 0 # even: Gauss rule does not include x == 0
         Ik = f(a + s) * w[end]
@@ -54,9 +51,6 @@ end
 function evalrule(f::InplaceIntegrand{F}, a,b, x,w,gw, nrm) where {F}
     # Ik and Ig are integrals via Kronrod and Gauss rules, respectively
     s = convert(eltype(x), 0.5) * (b-a)
-
-    (a == a + (1+x[1])*s || b == a + (1-x[1])*s) && return nothing  # check for endpoint roundoff
-
     n1 = 1 - (length(x) & 1) # 0 if even order, 1 if odd order
     fg, fk, Ig, Ik = f.fg, f.fk, f.Ig, f.Ik # pre-allocated temporary arrays
     f.f!(f.fx, a + s)

--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -15,6 +15,9 @@ Base.isless(i::Segment, j::Segment) = isless(i.E, j.E)
 function evalrule(f::F, a,b, x,w,gw, nrm) where {F}
     # Ik and Ig are integrals via Kronrod and Gauss rules, respectively
     s = convert(eltype(x), 0.5) * (b-a)
+
+    (a == a + (1+x[1])*s || b == a + (1-x[1])*s) && return nothing  # check for endpoint roundoff
+
     n1 = 1 - (length(x) & 1) # 0 if even order, 1 if odd order
     if n1 == 0 # even: Gauss rule does not include x == 0
         Ik = f(a + s) * w[end]
@@ -51,6 +54,9 @@ end
 function evalrule(f::InplaceIntegrand{F}, a,b, x,w,gw, nrm) where {F}
     # Ik and Ig are integrals via Kronrod and Gauss rules, respectively
     s = convert(eltype(x), 0.5) * (b-a)
+
+    (a == a + (1+x[1])*s || b == a + (1-x[1])*s) && return nothing  # check for endpoint roundoff
+
     n1 = 1 - (length(x) & 1) # 0 if even order, 1 if odd order
     fg, fk, Ig, Ik = f.fg, f.fk, f.Ig, f.Ik # pre-allocated temporary arrays
     f.f!(f.fx, a + s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,7 +347,7 @@ end
     @test quadgk(BatchIntegrand{Float64}((y,x)-> @.(y = 1/x^1.1)),1,Inf)[1] ≈ I rtol=0.05
 
     # if order < 85, there is also a DomainError, but due to overflow of the change of variables
-    errmsg = "integrand evaluated at an endpoint"
+    errmsg = "roundoff error detected near endpoint of the initial interval"
     @test_throws errmsg quadgk(x -> x, Float16(1), Float16(Inf), order=85)
     @test_throws errmsg quadgk!((y,x) -> x, Float16[1], Float16(1), Float16(Inf), order=85)
     @test_throws errmsg quadgk(BatchIntegrand{Float16}((y,x) -> y .= x), Float16(1), Float16(Inf), order=85)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,7 +348,7 @@ end
 
     # if order < 85, there is also a DomainError, but due to overflow of the change of variables
     errmsg = "roundoff error detected near endpoint of the initial interval"
-    @test_throws errmsg quadgk(x -> x, Float16(1), Float16(Inf), order=85)
-    @test_throws errmsg quadgk!((y,x) -> x, Float16[1], Float16(1), Float16(Inf), order=85)
-    @test_throws errmsg quadgk(BatchIntegrand{Float16}((y,x) -> y .= x), Float16(1), Float16(Inf), order=85)
+    @test_throws errmsg quadgk(x -> x, Float16(1), Float16(Inf), order=90)
+    @test_throws errmsg quadgk!((y,x) -> x, Float16[1], Float16(1), Float16(Inf), order=90)
+    @test_throws errmsg quadgk(BatchIntegrand{Float16}((y,x) -> y .= x), Float16(1), Float16(Inf), order=90)
 end


### PR DESCRIPTION
This pr concerns issues #86, #82, and #39, and addresses errors arising from evaluation of the integrand at the endpoints of the interval. This pr handles the endpoints by:
* throwing a `DomainError` if the roundoff happens on an initial segment
* silently returning the best integral and error estimate if the roundoff happens during refinement

I think it would be better to warn the user of the following situations in which `quadgk` silently returns a possibly unconverged result
* endpoint roundoff error
* maxevals reached

Should we do this and add return codes?