### PR TITLE
Use BaseType.jl instead of Base.one to get scalar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,12 @@ uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 version = "2.9.1"
 
 [deps]
+BaseType = "7fbed51b-1ef5-4d67-9085-a4a9b26f478c"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
+BaseType = "0.2"
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 julia = "1.2"
 

--- a/src/QuadGK.jl
+++ b/src/QuadGK.jl
@@ -26,7 +26,7 @@ module QuadGK
 export quadgk, quadgk!, gauss, kronrod, alloc_segbuf, quadgk_count, quadgk_print
 export BatchIntegrand
 
-using DataStructures, LinearAlgebra
+using DataStructures, LinearAlgebra, BaseType
 import Base.Order.Reverse
 
 # an in-place integrand function f!(result, x) and

--- a/src/gausskronrod.jl
+++ b/src/gausskronrod.jl
@@ -569,4 +569,4 @@ end
 end
 
 cachedrule(::Type{T}, n::Integer) where {T<:Number} =
-    _cachedrule(typeof(float(real(one(T)))), Int(n))
+    _cachedrule(typeof(float(one(base_numeric_type(T)))), Int(n))


### PR DESCRIPTION
x-ref https://github.com/JuliaMath/QuadGK.jl/issues/88, https://github.com/JuliaPhysics/Measurements.jl/pull/155, https://github.com/SymbolicML/DynamicQuantities.jl/issues/40

I've confirmed that with this change as well as the intended change to make `AbstractQuantity <: Number`, DynamicQuantities.jl is now compatible with QuadGK.jl. And this allows me to keep  `Base.one(::Quantity) -> Quantity`.

BaseType.jl should already work for all types I can think of due to the default behavior, but feel free to wait until more interfaces are explicitly declared (e.g., https://github.com/JuliaPhysics/Measurements.jl/pull/155)