### PR TITLE
rename gw -> wg

### DIFF
--- a/docs/src/gauss-kronrod.md
+++ b/docs/src/gauss-kronrod.md
@@ -135,7 +135,7 @@ add more points mostly in these "bad" regions.)
 You can use the [`kronrod`](@ref) function to compute a Gauss–Kronrod
 rule to any desired order (and to any precision).  For example, we can extend our 5-point Gaussian-quadrature rule for $\int_1^3$ from the previous section to an 11-point (`2n+1`) Gauss-Kronrod rule:
 ```julia-repl
-julia> x, w, gw = kronrod(n, a, b); [ x w ] # points and weights
+julia> x, w, wg = kronrod(n, a, b); [ x w ] # points and weights
 11×2 Matrix{Float64}:
  1.01591  0.042582
  1.09382  0.115233
@@ -152,11 +152,11 @@ julia> x, w, gw = kronrod(n, a, b); [ x w ] # points and weights
 Similar to Gaussian quadrature, notice that all of the Gauss–Kronrod points
 $a < x_i < b$ lie in the interior $(a,b)$ of our integration interval,
 and that they are unequally spaced (clustered more near the edges).
-The third return value, `gw`, gives the weights of the embedded 5-point
+The third return value, `wg`, gives the weights of the embedded 5-point
 Gaussian-quadrature rule, which corresponds to the *even-indexed* points
 `x[2:2:end]` of the 11-point Gauss–Kronrod rule:
 ```julia-repl
-julia> [ x[2:2:end] gw ] # embedded Gauss points and weights
+julia> [ x[2:2:end] wg ] # embedded Gauss points and weights
 5×2 Matrix{Float64}:
  1.09382  0.236927
  1.46153  0.478629
@@ -171,7 +171,7 @@ julia> fx = cos.(x); # evaluate f(xᵢ)
 julia> integral = sum(w .* fx) # ∑ᵢ wᵢ f(xᵢ)
 -0.7003509767480292
 
-julia> error = abs(integral - sum(gw .* fx[2:2:end])) # |integral - ∑ⱼ wⱼ′ f(xⱼ′)|
+julia> error = abs(integral - sum(wg .* fx[2:2:end])) # |integral - ∑ⱼ wⱼ′ f(xⱼ′)|
 3.2933822335934337e-10
 
 julia> abs(integral - (sin(3) - sin(1))) # true error ≈ machine precision
@@ -184,7 +184,7 @@ is so good that it is actually limited by [floating-point roundoff error](https:
 You may notice that both the Gauss–Kronrod and the Gaussian quadrature
 rules are *symmetric* around the center $(a+b)/2$ of the integration interval.   In fact, we provide a lower-level function `kronrod(n)` that only computes roughly the first half of the points and weights for $\int_{-1}^{1}$ ($b = -a = 1$), corresponding to $x_i \le 0$.
 ```julia-repl
-julia> x, w, gw = kronrod(5); [x w] # points xᵢ ≤ 0 and weights
+julia> x, w, wg = kronrod(5); [x w] # points xᵢ ≤ 0 and weights
 6×2 Matrix{Float64}:
  -0.984085  0.042582
  -0.90618   0.115233
@@ -193,7 +193,7 @@ julia> x, w, gw = kronrod(5); [x w] # points xᵢ ≤ 0 and weights
  -0.27963   0.27285
   0.0       0.282987
 
-julia> [x[2:2:end] gw] # embedded Gauss points ≤ 0 and weights
+julia> [x[2:2:end] wg] # embedded Gauss points ≤ 0 and weights
 3×2 Matrix{Float64}:
  -0.90618   0.236927
  -0.538469  0.478629
@@ -213,7 +213,7 @@ the endpoints `(a,b)` (converted to floating point), while for
 `kronrod(n)` you can explicitly pass a floating-point type `T` as
 the first argument, e.g. for 50-digit precision:
 ```julia-repl
-julia> setprecision(50, base=10); x, w, gw = kronrod(BigFloat, 5); x
+julia> setprecision(50, base=10); x, w, wg = kronrod(BigFloat, 5); x
 6-element Vector{BigFloat}:
  -0.9840853600948424644961729346361394995805528241884714
  -0.9061798459386639927976268782993929651256519107625304

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,7 @@ end
 # check some arbitrary precision (Maple) values from https://keisan.casio.com/exec/system/1289382036
 @testset "kronrod" begin
     setprecision(200) do
-        for (n,x0,w0,gw0) in (
+        for (n,x0,w0,wg0) in (
             (1, [big"-0.77459666924148337703585307995647992216658434105832", big"0.0"],
                 [big"0.55555555555555555555555555555555555555555555555556", big"0.88888888888888888888888888888888888888888888888889"],
                 [big"2.0"]),
@@ -126,32 +126,32 @@ end
                     # test generic Kronrod algorithm that doesn't
                     # assume a Jacobi matrix with zero diagonals
                     J = SymTridiagonal(zeros(BigFloat, m), b)
-                    x,w,gw = kronrod(Matrix(J), n, 2)
-                    @test kronrod(Matrix(J), n, 2, (-1,1)=>(-1,1)) ≅ (x,w,gw) atol=1e-55
-                    @test kronrod(QuadGK.HollowSymTridiagonal(b), n, 2, (-1,1)=>(-1,1)) ≅ (x,w,gw) atol=1e-55
-                    @test kronrod(n, big"-1.", big"1.") ≅ (x,w,gw) atol=1e-55
+                    x,w,wg = kronrod(Matrix(J), n, 2)
+                    @test kronrod(Matrix(J), n, 2, (-1,1)=>(-1,1)) ≅ (x,w,wg) atol=1e-55
+                    @test kronrod(QuadGK.HollowSymTridiagonal(b), n, 2, (-1,1)=>(-1,1)) ≅ (x,w,wg) atol=1e-55
+                    @test kronrod(n, big"-1.", big"1.") ≅ (x,w,wg) atol=1e-55
                     # check symmetric rule & remove redundant points/weights
                     @test x[1:n] ≈ -reverse(x[n+2:end]) atol=1e-55
                     @test w[1:n] ≈ reverse(w[n+2:end]) atol=1e-55
                     resize!(x, n+1)
                     resize!(w, n+1)
-                    resize!(gw, length(2:2:n+1))
+                    resize!(wg, length(2:2:n+1))
                 else
                     # test generic HollowSymTridiagonal method
                     J = QuadGK.HollowSymTridiagonal(b)
-                    x,w,gw = kronrod(J, n, 2)
+                    x,w,wg = kronrod(J, n, 2)
                 end
             else
-                x,w,gw = kronrod(BigFloat, n)
+                x,w,wg = kronrod(BigFloat, n)
             end
             @test (x,w) ≅ (x0,w0) atol=1e-49
-            @test gw ≈ gw0 atol=1e-49
+            @test wg ≈ wg0 atol=1e-49
 
             xg, wg = gauss(n, big"-1", big"+1")
             nn = length(2:2:n+1)
             nn0 = length(2:2:n)
             @test wg[1:nn0] ≈ reverse(wg[nn+1:end]) atol=1e-55
-            @test wg[1:nn] ≈ gw0 atol=1e-49
+            @test wg[1:nn] ≈ wg0 atol=1e-49
         end
     end
 


### PR DESCRIPTION
In some places we wrote the Gauss weights as `wg`, and in others as `gw`.  This PR changes the code and docs to use `wg` consistently.

(Not breaking.)

Fixes #106.