### PR TITLE
omit pointless extra Newton iteration for λ

### DIFF
--- a/src/gausskronrod.jl
+++ b/src/gausskronrod.jl
@@ -139,9 +139,6 @@ function eignewt(H::AbstractSymTri{T}, n::Integer) where {T<:Real}
             if isfinite(δλ)
                 lambda[i] -= δλ
                 if abs(δλ) ≤ 10 * eps(lambda[i])
-                    # do one final Newton iteration for luck and profit:
-                    δλ = eigpolyrat(H,lambda[i])
-                    lambda[i] -= δλ
                     break
                 end
             else


### PR DESCRIPTION
Since Newton iterations should be quadratically converging by the time we approach machine precision, the final iteration here is pointless (the next correction should be of order $\varepsilon^2$).