### PR TITLE
add Enzyme to "extras" for testing, docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.6'
           - '1.9'
           - '1'
 #          - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,11 @@ QuadGKEnzymeExt = "Enzyme"
 [compat]
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
 Enzyme = "0.12"
-julia = "1.2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Enzyme"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ QuadGKEnzymeExt = "Enzyme"
 
 [compat]
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19"
+LinearAlgebra = "<0.0.1, 1"
 Enzyme = "0.12"
 julia = "1.6"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -439,9 +439,12 @@ quadgk_segbuf_printnull(args...; kws...) = quadgk_segbuf_print(devnull, args...;
     @test E3 ≈ E3′ rtol=1e-15
     @test count3′ == length(segbuf3) * 15
 
-    # type inference of to_segbuf for concrete types:
-    @inferred QuadGK.to_segbuf([0,1])
-    @inferred QuadGK.to_segbuf([(0,1+3im)])
+    # type inference of to_segbuf for concrete types
+    # (fails due to apparent Julia inference limitation for some older versions):
+    if VERSION >= v"1.9"
+        @inferred QuadGK.to_segbuf([0,1])
+        @inferred QuadGK.to_segbuf([(0,1+3im)])
+    end
 end
 
 # Extension package only supported in 1.9+


### PR DESCRIPTION
This adds the new weakdep Enzyme to the "extras" section and for testing.

Also adds a compat entry for the stdlib LinearAlgebra since [that is required nowadays](https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958).

bumps the Julia version requirement to 1.6 since that is needed by Enzyme (a test dependency even though it is optional for installation), and it is a pain to continue to support 1.2 with this dependency present.  Not much point in supporting ancient Julia versions these days.