### PR TITLE
Fix in-place broadcast fusion in evalrule

### DIFF
--- a/src/evalrule.jl
+++ b/src/evalrule.jl
@@ -61,9 +61,9 @@ function evalrule(f::InplaceIntegrand{F}, a,b, x,w,wg, nrm) where {F}
         Ig .= zero.(Ik)
     else # odd: don't count x==0 twice in Gauss rule
         Ig .= f.fx .* wg[end]
-        f.f!(f.fg, a + (1+x[end-1])*s)
-        f.f!(f.fk, a + (1-x[end-1])*s)
-        Ik .= f.fx .* w[end] .+ (f.fg + f.fk) .* w[end-1]
+        f.f!(fg, a + (1+x[end-1])*s)
+        f.f!(fk, a + (1-x[end-1])*s)
+        Ik .= f.fx .* w[end] .+ (fg .+ fk) .* w[end-1]
     end
     for i = 1:length(wg)-n1
         eval2x!(fg, f, a + (1+x[2i])*s, a + (1-x[2i])*s)


### PR DESCRIPTION
Was perusing the code and noticed a missing dot resulting in an unnecessary intermediate allocation. Also changed these three lines to use the already unpacked names `fg,fk` rather than access them as properties of `f`.