### PR TITLE
Match half-infinite interval endpoint handling behaviour with infinite interval

### DIFF
--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -175,12 +175,12 @@ function handle_infinities(workfunc, f, s)
                 if si < zero(si) # x = s0 - t/(1-t)
                     return workfunc(t -> begin den = 1 / (1 - t);
                                                 f(s0 - oneunit(s1)*t*den) * den*den*oneunit(s1); end,
-                                    reverse(map(x -> 1 / (1 + oneunit(x) / (s0 - x)), s)),
+                                    reverse(map(x -> x == s0 ? zero(x) : isinf(x) ? one(x) : 1 / (1 + oneunit(x) / (s0 - x)), s)),
                                     t -> s0 - oneunit(s1)*t/(1-t))
                 else # x = s0 + t/(1-t)
                     return workfunc(t -> begin den = 1 / (1 - t);
                                                 f(s0 + oneunit(s1)*t*den) * den*den*oneunit(s1); end,
-                                    map(x -> 1 / (1 + oneunit(x) / (x - s0)), s),
+                                    map(x -> x == s0 ? zero(x) : isinf(x) ? one(x) : 1 / (1 + oneunit(x) / (x - s0)), s),
                                     t -> s0 + oneunit(s1)*t/(1-t))
                 end
             end

--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -205,12 +205,12 @@ function handle_infinities(workfunc, f::InplaceIntegrand, s)
                 if si < zero(si) # x = s0 - t/(1-t)
                     return workfunc(InplaceIntegrand((v, t) -> begin den = 1 / (1 - t);
                                             f.f!(ftmp, s0 - oneunit(s1)*t*den); v .= ftmp .* (den * den * oneunit(s1)); end, f.I, f.fx * oneunit(s1)),
-                                    reverse(map(x -> 1 / (1 + oneunit(x) / (s0 - x)), s)),
+                                    reverse(map(x -> x == s0 ? zero(x) : isinf(x) ? one(x) : 1 / (1 + oneunit(x) / (s0 - x)), s)),
                                     t -> s0 - oneunit(s1)*t/(1-t))
                 else # x = s0 + t/(1-t)
                     return workfunc(InplaceIntegrand((v, t) -> begin den = 1 / (1 - t);
                                             f.f!(ftmp, s0 + oneunit(s1)*t*den); v .= ftmp .* (den * den * oneunit(s1)); end, f.I, f.fx * oneunit(s1)),
-                                    map(x -> 1 / (1 + oneunit(x) / (x - s0)), s),
+                                    map(x -> x == s0 ? zero(x) : isinf(x) ? one(x) : 1 / (1 + oneunit(x) / (x - s0)), s),
                                     t -> s0 + oneunit(s1)*t/(1-t))
                 end
             end


### PR DESCRIPTION
I ran into this issue when running `quadgk` using the `ArbReal` type from `ArbNumerics.jl`:

```julia
julia> using QuadGK, ArbNumerics

julia> quadgk(x->exp(-x^2/2), ArbReal.((0, Inf))...; rtol = 1e-30)
ERROR: DomainError with nan:
integrand produced nan in the interval (nan, 1.0)
Stacktrace:
 [1] evalrule(f::QuadGK.var"#188#197"{…}, a::ArbReal{…}, b::ArbReal{…}, x::Vector{…}, w::Vector{…}, wg::Vector{…}, nrm::typeof(norm))
   @ QuadGK ~/.julia/dev/QuadGK/src/evalrule.jl:39
 [2] #8
   @ ~/.julia/dev/QuadGK/src/adapt.jl:54 [inlined]
 [3] ntuple
   @ ./ntuple.jl:48 [inlined]
 [4] do_quadgk(f::QuadGK.var"#188#197"{…}, s::Tuple{…}, n::Int64, atol::Nothing, rtol::Float64, maxevals::Int64, nrm::typeof(norm), _segbuf::Nothing, eval_segbuf::Nothing)
   @ QuadGK ~/.julia/dev/QuadGK/src/adapt.jl:52
 [5] #50
   @ ~/.julia/dev/QuadGK/src/api.jl:83 [inlined]
 [6] handle_infinities(workfunc::QuadGK.var"#50#51"{…}, f::var"#193#194", s::Tuple{…})
   @ QuadGK ~/.julia/dev/QuadGK/src/adapt.jl:181
 [7] quadgk(::var"#193#194", ::ArbReal{…}, ::Vararg{…}; atol::Nothing, rtol::Float64, maxevals::Int64, order::Int64, norm::Function, segbuf::Nothing, eval_segbuf::Nothing)
   @ QuadGK ~/.julia/dev/QuadGK/src/api.jl:82
 [8] top-level scope
   @ REPL[17]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

This issue is due to this line

https://github.com/JuliaMath/QuadGK.jl/blob/9d44aa65bbd79de81bc690f0cf3b551355ac75d9/src/adapt.jl#L183

which relies on `oneunit(x) / (x - s0)` returning `+Inf` when `x == s0`, but unfortunately for `ArbReal` this returns `NaN`:

```julia
julia> 1 / ArbReal(0.0)
nan
```

This is arguably a bug in `ArbNumerics.jl`, but I still think it's worth adding the shortcut here anyways, since we know the exact value at the endpoints by construction. This is already handled in the infinite interval case

https://github.com/JuliaMath/QuadGK.jl/blob/9d44aa65bbd79de81bc690f0cf3b551355ac75d9/src/adapt.jl#L171

and so integrating over the whole real line works with `ArbReal` already:
```julia
julia> quadgk(x->exp(-x^2/2), ArbReal.((-Inf, Inf))...; rtol = 1e-30)
(2.506628274631000502415765284811045253006986763646814215739578625422900663855632674562267772719054355040278933964528512775218832653683467544736471861, 2.4335579847571049084908631922123419973557630229112438434655882328882057936651770438785297425820911894881138469219037412917528066670016801291961945860810636788846974668305804057570091784e-30)
```

It's worth noting that the current behaviour "just barely" works for `Double64` from `DoubleFloats.jl`, since

```julia
julia> 1 / Double64(0.0)
Inf

julia> inv(Double64(0.0))
NaN
```

and so if this transformation had been written using `inv` it would have failed for `Double64` as well. In general I think it is just best to not rely on the behaviour of `1 / 0` if it can be avoided.