### PR TITLE
Bump version 2.11.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuadGK"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.11.2"
+version = "2.11.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
This is mainly so that the new docs show up as the stable version, but also the changes in adapt.jl seem significant enough to warrant a new version.